### PR TITLE
Fixed color encoding problem causing Issue #178

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -359,4 +359,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf.encode('utf-8'))
+  print(linebuf)


### PR DESCRIPTION
Removed utf-8 encoding step as recommended in https://github.com/JakeWharton/pidcat/issues/97#issuecomment-932760684. This is backwards-compatible with Python 2.